### PR TITLE
経験値バーの最適化

### DIFF
--- a/data/tag/functions/freezing_level/sync_xpbar.mcfunction
+++ b/data/tag/functions/freezing_level/sync_xpbar.mcfunction
@@ -1,13 +1,13 @@
 # 参考動画: 経験値バーを自由に操作しよう！【マイクラコマンド解説】
 # https://youtu.be/Dtn_FQcDF8E
 
-# レベル 129 はポイントが 0~1002
-xp set @s 129 levels
+# レベル 28 はポイントが 0~102
+xp set @s 28 levels
 execute store result score #points TAG.xpbar run xp query @s points
 
 # 凍結度を経験値の値に変換
 scoreboard players operation #diff TAG.xpbar = @s TAG.freeze_percentage
-scoreboard players operation #diff TAG.xpbar *= #1000 TAG.xpbar
+scoreboard players operation #diff TAG.xpbar *= #104 TAG.xpbar
 scoreboard players operation #diff TAG.xpbar /= #max TAG.freeze_percentage
 scoreboard players operation #diff TAG.xpbar -= #points TAG.xpbar
 scoreboard players operation #diff TAG.xpbar /= #4 TAG.xpbar
@@ -15,12 +15,6 @@ scoreboard players operation #points TAG.xpbar += #diff TAG.xpbar
 
 # スコアを経験値に代入
 xp set @s 0 points
-execute if score #points TAG.xpbar matches 512.. run xp add @s 512 points
-execute if score #points TAG.xpbar matches 512.. run scoreboard players remove #points TAG.xpbar 512
-execute if score #points TAG.xpbar matches 256.. run xp add @s 256 points
-execute if score #points TAG.xpbar matches 256.. run scoreboard players remove #points TAG.xpbar 256
-execute if score #points TAG.xpbar matches 128.. run xp add @s 128 points
-execute if score #points TAG.xpbar matches 128.. run scoreboard players remove #points TAG.xpbar 128
 execute if score #points TAG.xpbar matches 64.. run xp add @s 64 points
 execute if score #points TAG.xpbar matches 64.. run scoreboard players remove #points TAG.xpbar 64
 execute if score #points TAG.xpbar matches 32.. run xp add @s 32 points

--- a/data/tag/functions/freezing_level/sync_xpbar.mcfunction
+++ b/data/tag/functions/freezing_level/sync_xpbar.mcfunction
@@ -41,12 +41,6 @@ xp set @s 0 levels
 scoreboard players operation #levels TAG.xpbar = @s TAG.freeze_percentage
 scoreboard players operation #levels TAG.xpbar /= #10 TAG.xpbar
 
-execute if score #levels TAG.xpbar matches 512.. run xp add @s 512 levels
-execute if score #levels TAG.xpbar matches 512.. run scoreboard players remove #levels TAG.xpbar 512
-execute if score #levels TAG.xpbar matches 256.. run xp add @s 256 levels
-execute if score #levels TAG.xpbar matches 256.. run scoreboard players remove #levels TAG.xpbar 256
-execute if score #levels TAG.xpbar matches 128.. run xp add @s 128 levels
-execute if score #levels TAG.xpbar matches 128.. run scoreboard players remove #levels TAG.xpbar 128
 execute if score #levels TAG.xpbar matches 64.. run xp add @s 64 levels
 execute if score #levels TAG.xpbar matches 64.. run scoreboard players remove #levels TAG.xpbar 64
 execute if score #levels TAG.xpbar matches 32.. run xp add @s 32 levels

--- a/data/tag/functions/init.mcfunction
+++ b/data/tag/functions/init.mcfunction
@@ -23,7 +23,7 @@ scoreboard players set #2 TAG.freeze_unit_mode 2
 
 # 経験値の同期
 scoreboard objectives add TAG.xpbar dummy
-scoreboard players set #1000 TAG.xpbar 1000
+scoreboard players set #104 TAG.xpbar 104
 scoreboard players set #4 TAG.xpbar 4
 scoreboard players set #10 TAG.xpbar 10
 


### PR DESCRIPTION
## やったこと
* 不必要な経験値レベルの代入処理
    - 100より上の数値は表示されないので、その処理を削除
* 経験値バーの操作を最適化
    - ベースとなるレベルを129lvl(1002pt)から28lvl(102pt)に変更
    - 不必要な代入処理を削除


## やらないこと
* なし


## その他

